### PR TITLE
php 8 array_merge()

### DIFF
--- a/src/Descriptor/TextDescriptor.php
+++ b/src/Descriptor/TextDescriptor.php
@@ -173,7 +173,7 @@ final class TextDescriptor extends SymfonyTextDescriptor
 					{
 						return array_intersect($namespace['commands'], array_keys($commands));
 					},
-					$namespaces
+					array_values($namespaces)
 				)
 			)
 		);


### PR DESCRIPTION

### Summary of Changes
php8 array_merge() does not accept unknown named parameters
### Testing Instructions
on console run php cli/joomla.php with php 8


