### PR TITLE
Allow composer install on PHP 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
     "homepage": "https://github.com/joomla-framework/console",
     "license": "GPL-2.0-or-later",
     "require": {
-        "php": "^7.2.5",
+        "php": "^7.2.5|^8.0",
         "joomla/application": "^2.0",
         "joomla/event": "^2.0",
         "joomla/string": "^2.0",


### PR DESCRIPTION
Our current setup doesn't actually allow install of framework projects on PHP 8 (e.g. per https://github.com/composer/composer/issues/9529). Obviously it should :)