### PR TITLE
[PHP8.4] Deprecate implicitly nullable parameter types

### DIFF
--- a/src/Descriptor/ApplicationDescription.php
+++ b/src/Descriptor/ApplicationDescription.php
@@ -146,8 +146,8 @@ final class ApplicationDescription
     /**
      * Returns the namespace part of the command name.
      *
-     * @param   string   $name   The command name to process
-     * @param   integer  $limit  The maximum number of parts of the namespace
+     * @param   string    $name   The command name to process
+     * @param   ?integer  $limit  The maximum number of parts of the namespace
      *
      * @return  string
      *

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -657,7 +657,7 @@ class ApplicationTest extends TestCase
         $this->assertSame(BeforeCommandExecuteEvent::RETURN_CODE_DISABLED, $app->getExitCode());
     }
 
-    private function buildMockClosingApplication(InputInterface $input = null, OutputInterface $output = null): Application
+    private function buildMockClosingApplication(?InputInterface $input = null, ?OutputInterface $output = null): Application
     {
         return new class ($input, $output) extends Application {
             private $exitCode  = 0;


### PR DESCRIPTION
### Summary of Changes

updates for [Deprecate implicitly nullable parameter types](https://wiki.php.net/rfc/deprecate-implicitly-nullable-types)

### Testing Instructions

code review

### Documentation Changes Required

no