### PR TITLE
[3.x][PHP8.5] setAccessible() methods of various Reflection objects have been deprecated

### DIFF
--- a/src/Event/ApplicationErrorEvent.php
+++ b/src/Event/ApplicationErrorEvent.php
@@ -104,7 +104,6 @@ class ApplicationErrorEvent extends ConsoleEvent
         $this->exitCode = $exitCode;
 
         $r = new \ReflectionProperty($this->error, 'code');
-        $r->setAccessible(true);
         $r->setValue($this->error, $this->exitCode);
     }
 }

--- a/src/Event/CommandErrorEvent.php
+++ b/src/Event/CommandErrorEvent.php
@@ -108,7 +108,6 @@ class CommandErrorEvent extends ConsoleEvent
         $this->exitCode = $exitCode;
 
         $r = new \ReflectionProperty($this->error, 'code');
-        $r->setAccessible(true);
         $r->setValue($this->error, $this->exitCode);
     }
 }

--- a/tests/ApplicationTest.php
+++ b/tests/ApplicationTest.php
@@ -289,7 +289,6 @@ class ApplicationTest extends TestCase
         // Simulates passing the --help option
         $r = new \ReflectionObject($this->object);
         $p = $r->getProperty('wantsHelp');
-        $p->setAccessible(true);
         $p->setValue($this->object, true);
 
         /** @var HelpCommand $helpCommand */


### PR DESCRIPTION
### Summary of Changes

> The “Make reflection setAccessible() no-op” RFC in PHP 8.1 made the Reflection*::setAccessible() methods a noop. However it did not deprecate the methods to simplify cross-version compatibility.

https://wiki.php.net/rfc/deprecations_php_8_5#deprecate_reflectionsetaccessible

### Testing Instructions

Run unit tests `./vendor/bin/phpunit`
- enable max error reporting
- use php 8.5 (latest pre-version 8.5.0rc1)

### Documentation Changes Required

no